### PR TITLE
Add example of decoding ids tokens into texts and Padding

### DIFF
--- a/src/CovostDataset.py
+++ b/src/CovostDataset.py
@@ -68,15 +68,15 @@ class CovostDataset(Dataset):
         for i in range(len(data)):
             tensor_fbank_wave = torch.Tensor(data[i]['fbank_wave']).view(1,-1,data[0]['fbank_wave'].shape[1])
             total_padding = max_frames-data[i]['fbank_wave'].shape[0]
-        
+            
             # Hack: Padding size should be less than the corresponding input dimension
             while total_padding>=data[i]['fbank_wave'].shape[0]:
-                tensor_fbank_wave = F.pad(tensor_fbank_wave, (0,0,0,data[i]['fbank_wave'].shape[0]-1), mode='reflect')
+                tensor_fbank_wave = F.pad(tensor_fbank_wave, (0,0,0,data[i]['fbank_wave'].shape[0]-1), mode='constant', value=0)
                 total_padding -= (data[i]['fbank_wave'].shape[0]-1)
             
-            tensor_fbank_wave = F.pad(tensor_fbank_wave, (0,0,0,total_padding), mode='reflect')
+            tensor_fbank_wave = F.pad(tensor_fbank_wave, (0,0,0,total_padding), mode='constant', value = 0)
             fbank_waves = torch.cat((fbank_waves, tensor_fbank_wave), 0)
-        
+
         return fbank_waves, n_frames, tgt_texts, speakers
         
     def collate_fn(self, all_data):

--- a/src/testing_CovostDataset.py
+++ b/src/testing_CovostDataset.py
@@ -22,11 +22,16 @@ args = parser.parse_args()
 
 train_dataset = CovostDataset(tsv_root=tsv_root, zip_fbank_path=zip_fbank_path, corpus_path=corpus_path, args=args)
 
+
 train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=args.batch_size, collate_fn=train_dataset.collate_fn)
 
 for i_batch, sample_batched in enumerate(train_dataloader):
     b_waves, b_frames, b_texts, b_speakers = sample_batched[0]['fbank_waves'], sample_batched[0]['n_frames'], \
                                                 sample_batched[0]['tgt_texts'], sample_batched[0]['speakers']
+    
+    print('Example of decoding from ids to text:')
+    print(f'Ids: {b_texts[0]}')
+    print(f'Texts: {train_dataset.tokenizer.sp.decode_ids(b_texts[0])}')
     
     print(f'batch number: {i_batch} done')
     

--- a/src/tokenizer.py
+++ b/src/tokenizer.py
@@ -12,7 +12,7 @@ class CovostTokenizer(object):
 
         self.model_prefix = 'm'+self.src_lan+'_'+self.tgt_lan
         spm.SentencePieceTrainer.train(input=self.corpus_root, vocab_size=self.vocab_size, model_prefix=self.model_prefix,
-                                        pad_id=1, unk_id=3, bos_id=0, eos_id=2, pad_piece='<pad>', 
+                                        pad_id=0, unk_id=3, bos_id=1, eos_id=2, pad_piece='<pad>', 
                                         unk_piece='<unk>', bos_piece='<s>', eos_piece='</s>')
         
         sp = spm.SentencePieceProcessor()


### PR DESCRIPTION
I modified the testing_CovostDataset.py to add the example of decoding a list of token ids into a text. The `tokenizer` of CovostDataset should be used. From this tokenizer, `decode_ids` method from `sp` attribute decodes the list of ids and outputs a text.

**Example:**
First create the CovostDataset object:
`train_dataset = CovostDataset(tsv_root=tsv_root, zip_fbank_path=zip_fbank_path, corpus_path=corpus_path, args=args)`

Then in the iteration with a DataLoader, we can run the following code to print the decoded token ids from the first sample of the given batch:
```
print('Example of decoding from ids to text:')
print(f'Ids: {b_texts[0]}')
print(f'Texts: {train_dataset.tokenizer.sp.decode_ids(b_texts[0])}')
print(f'batch number: {i_batch} done')
```

Resulting on this:
```
Example of decoding from ids to text:
Ids: [1, 1325, 198, 11, 1117, 1414, 5, 7, 1680, 19, 6, 609, 815, 287, 4, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
Texts: Just like in previous editions, Uruguay was the classified team.
```

Recall that 0, 1 , and 2 are the PAD, BOS, and EOS tokens, respectively.
Also note that 0 is used for padding audio with filter banks too.